### PR TITLE
Fix calculation of cube to offset

### DIFF
--- a/HexCell.gd
+++ b/HexCell.gd
@@ -169,9 +169,9 @@ func get_offset_coords():
 func set_offset_coords(val):
 	# Sets position from a Vector2 of offset coordinates
 	var x = int(val.x)
-	var y = int(val.y)
-	var cube_y = y - (x - (x & 1)) / 2
-	self.set_axial_coords(Vector2(x, cube_y))
+	var z = int(val.z)
+	var cube_z = z - (x - (x & 1)) / 2
+	self.set_axial_coords(Vector2(x, cube_z))
 	
 
 """


### PR DESCRIPTION
According to [the guide](https://www.redblobgames.com/grids/hexagons/#conversions-offset), the conversion of cube to odd-q offset uses the z-axis, not the y-axis. I spent a while yesterday trying to debug why godot was not aligning the hex correctly and I noted you're using the wrong axis.