### PR TITLE
Convert to plugin

### DIFF
--- a/addons/gdhexgrid/HexCell.gd
+++ b/addons/gdhexgrid/HexCell.gd
@@ -1,66 +1,67 @@
 """
 	A single cell of a hexagonal grid.
-	
+
 	There are many ways to orient a hex grid, this library was written
 	with the following assumptions:
-	
+
 	* The hexes use a flat-topped orientation;
 	* Axial coordinates use +x => NE; +y => N;
 	* Offset coords have odd rows shifted up half a step.
-	
+
 	Using x,y instead of the reference's preferred x,z for axial coords makes
 	following along with the reference a little more tricky, but is less confusing
 	when using Godot's Vector2(x, y) objects.
-	
-	
+
+
 	## Usage:
-	
+
 	#### var cube_coords; var axial_coords; var offset_coords
 
 		Cube coordinates are used internally as the canonical representation, but
 		both axial and offset coordinates can be read and modified through these
 		properties.
-	
+
 	#### func get_adjacent(direction)
-	
+
 		Returns the neighbouring HexCell in the given direction.
-		
+
 		The direction should be one of the DIR_N, DIR_NE, DIR_SE, DIR_S, DIR_SW, or
 		DIR_NW constants provided by the HexCell class.
-	
+
 	#### func get_all_adjacent()
-	
+
 		Returns an array of the six HexCell instances neighbouring this one.
-	
+
 	#### func get_all_within(distance)
-	
+
 		Returns an array of all the HexCells within the given number of steps,
 		including the current hex.
-	
+
 	#### func get_ring(distance)
-	
+
 		Returns an array of all the HexCells at the given distance from the current.
-	
+
 	#### func distance_to(target)
-	
+
 		Returns the number of hops needed to get from this hex to the given target.
-		
+
 		The target can be supplied as either a HexCell instance, cube or axial
 		coordinates.
-	
+
 	#### func line_to(target)
-	
+
 		Returns an array of all the hexes crossed when drawing a straight line
 		between this hex and another.
-		
+
 		The target can be supplied as either a HexCell instance, cube or axial
 		coordinates.
-		
+
 		The items in the array will be in the order of traversal, and include both
 		the start (current) hex, as well as the final target.
 
 """
 extends Resource
+class_name HexCell, "icon_hex_cell.svg"
 #warning-ignore-all:unused_class_variable
 
 # We use unit-size flat-topped hexes
@@ -104,7 +105,7 @@ func obj_to_coords(val):
 	#
 	# NB that offset coords are NOT supported, as they are
 	# indistinguishable from axial coords.
-	
+
 	if typeof(val) == TYPE_VECTOR3:
 		return val
 	elif typeof(val) == TYPE_VECTOR2:
@@ -113,21 +114,21 @@ func obj_to_coords(val):
 		return val.get_cube_coords()
 	# Fall through to nothing
 	return
-	
+
 func axial_to_cube_coords(val):
 	# Returns the Vector3 cube coordinates for an axial Vector2
 	var x = val.x
 	var y = val.y
 	return Vector3(x, y, -x - y)
-	
+
 func round_coords(val):
 	# Rounds floaty coordinate to the nearest whole number cube coords
 	if typeof(val) == TYPE_VECTOR2:
 		val = axial_to_cube_coords(val)
-	
+
 	# Straight round them
 	var rounded = Vector3(round(val.x), round(val.y), round(val.z))
-	
+
 	# But recalculate the one with the largest diff so that x+y+z=0
 	var diffs = (rounded - val).abs()
 	if diffs.x > diffs.y and diffs.x > diffs.z:
@@ -136,43 +137,43 @@ func round_coords(val):
 		rounded.y = -rounded.x - rounded.z
 	else:
 		rounded.z = -rounded.x - rounded.y
-	
+
 	return rounded
-	
+
 
 func get_cube_coords():
 	# Returns a Vector3 of the cube coordinates
 	return cube_coords
-	
+
 func set_cube_coords(val):
 	# Sets the position from a Vector3 of cube coordinates
 	if abs(val.x + val.y + val.z) > 0.0001:
 		print("WARNING: Invalid cube coordinates for hex (x+y+z!=0): ", val)
 		return
 	cube_coords = round_coords(val)
-	
+
 func get_axial_coords():
 	# Returns a Vector2 of the axial coordinates
 	return Vector2(cube_coords.x, cube_coords.y)
-	
+
 func set_axial_coords(val):
 	# Sets position from a Vector2 of axial coordinates
 	set_cube_coords(axial_to_cube_coords(val))
-	
+
 func get_offset_coords():
 	# Returns a Vector2 of the offset coordinates
 	var x = int(cube_coords.x)
 	var y = int(cube_coords.y)
 	var off_y = y + (x - (x & 1)) / 2
 	return Vector2(x, off_y)
-	
+
 func set_offset_coords(val):
 	# Sets position from a Vector2 of offset coordinates
 	var x = int(val.x)
 	var y = int(val.y)
 	var cube_y = y - (x - (x & 1)) / 2
 	self.set_axial_coords(Vector2(x, cube_y))
-	
+
 
 """
 	Finding our neighbours
@@ -183,14 +184,14 @@ func get_adjacent(dir):
 	if typeof(dir) == TYPE_VECTOR2:
 		dir = axial_to_cube_coords(dir)
 	return new_hex(self.cube_coords + dir)
-	
+
 func get_all_adjacent():
 	# Returns an array of HexCell instances representing adjacent locations
 	var cells = Array()
 	for coord in DIR_ALL:
 		cells.append(new_hex(self.cube_coords + coord))
 	return cells
-	
+
 func get_all_within(distance):
 	# Returns an array of all HexCell instances within the given distance
 	var cells = Array()
@@ -198,7 +199,7 @@ func get_all_within(distance):
 		for dy in range(max(-distance, -distance - dx), min(distance, distance - dx) + 1):
 			cells.append(new_hex(self.axial_coords + Vector2(dx, dy)))
 	return cells
-	
+
 func get_ring(distance):
 	# Returns an array of all HexCell instances at the given distance
 	if distance < 1:
@@ -211,7 +212,7 @@ func get_ring(distance):
 			cells.append(current)
 			current = current.get_adjacent(dir)
 	return cells
-	
+
 func distance_to(target):
 	# Returns the number of hops from this hex to another
 	# Can be passed cube or axial coords, or another HexCell instance
@@ -221,7 +222,7 @@ func distance_to(target):
 			+ abs(cube_coords.y - target.y)
 			+ abs(cube_coords.z - target.z)
 			) / 2)
-	
+
 func line_to(target):
 	# Returns an array of HexCell instances representing
 	# a straight path from here to the target, including both ends
@@ -235,4 +236,4 @@ func line_to(target):
 		path.append(new_hex(round_coords(lerped)))
 	path.append(new_hex(target))
 	return path
-	
+

--- a/addons/gdhexgrid/gdhexgrid_plugin.gd
+++ b/addons/gdhexgrid/gdhexgrid_plugin.gd
@@ -1,0 +1,14 @@
+tool
+extends EditorPlugin
+
+func _enter_tree():
+	# Initialization of the plugin goes here
+	# Add the new type with a name, a parent type, a script and an icon
+	add_custom_type("HexCell", "Node", preload("HexCell.gd"), preload("icon_hex_cell.svg"))
+	add_custom_type("HexGrid", "Node", preload("HexGrid.gd"), preload("icon_hex_grid.svg"))
+
+func _exit_tree():
+	# Clean-up of the plugin goes here
+	# Always remember to remove it from the engine when deactivated
+	remove_custom_type("HexGrid")
+	remove_custom_type("HexCell")

--- a/addons/gdhexgrid/icon_hex_cell.svg
+++ b/addons/gdhexgrid/icon_hex_cell.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<path transform="translate(0 1036.4)" d="m8 2a6 6 0 0 0 -6 6 6 6 0 0 0 6 6 6 6 0 0 0 6 -6 6 6 0 0 0 -6 -6zm0 2a4 4 0 0 1 4 4 4 4 0 0 1 -4 4 4 4 0 0 1 -4 -4 4 4 0 0 1 4 -4z" fill="#e0e0e0"/>
+</g>
+</svg>

--- a/addons/gdhexgrid/icon_hex_cell.svg.import
+++ b/addons/gdhexgrid/icon_hex_cell.svg.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_hex_cell.svg-d808bc9b41e17af826359e422efef825.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/gdhexgrid/icon_hex_cell.svg"
+dest_files=[ "res://.import/icon_hex_cell.svg-d808bc9b41e17af826359e422efef825.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/addons/gdhexgrid/icon_hex_grid.svg
+++ b/addons/gdhexgrid/icon_hex_grid.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(0 -1036.4)">
+<path transform="translate(0 1036.4)" d="m8 2a6 6 0 0 0 -6 6 6 6 0 0 0 6 6 6 6 0 0 0 6 -6 6 6 0 0 0 -6 -6zm0 2a4 4 0 0 1 4 4 4 4 0 0 1 -4 4 4 4 0 0 1 -4 -4 4 4 0 0 1 4 -4z" fill="#e0e0e0"/>
+</g>
+</svg>

--- a/addons/gdhexgrid/icon_hex_grid.svg.import
+++ b/addons/gdhexgrid/icon_hex_grid.svg.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_hex_grid.svg-8a922e74b5f862707f16407719217d1d.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/gdhexgrid/icon_hex_grid.svg"
+dest_files=[ "res://.import/icon_hex_grid.svg-8a922e74b5f862707f16407719217d1d.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/addons/gdhexgrid/plugin.cfg
+++ b/addons/gdhexgrid/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="GDHexGrid"
+description="Tools for using hexagonal grids in GDScript."
+author="Mel Collins"
+version="1.0.0"
+script="gdhexgrid_plugin.gd"

--- a/demo_2d.gd
+++ b/demo_2d.gd
@@ -1,7 +1,7 @@
 # Script to attach to a node which represents a hex grid
 extends Node2D
 
-var HexGrid = preload("./HexGrid.gd").new()
+var hex_grid = HexGrid.new()
 
 onready var highlight = get_node("Highlight")
 onready var area_coords = get_node("Highlight/AreaCoords")
@@ -9,8 +9,8 @@ onready var hex_coords = get_node("Highlight/HexCoords")
 
 
 func _ready():
-	HexGrid.hex_scale = Vector2(50, 50)
-	
+	hex_grid.hex_scale = Vector2(50, 50)
+
 
 func _unhandled_input(event):
 	if 'position' in event:
@@ -19,8 +19,8 @@ func _unhandled_input(event):
 		if area_coords != null:
 			area_coords.text = str(relative_pos)
 		if hex_coords != null:
-			hex_coords.text = str(HexGrid.get_hex_at(relative_pos).axial_coords)
-		
+			hex_coords.text = str(hex_grid.get_hex_at(relative_pos).axial_coords)
+
 		# Snap the highlight to the nearest grid cell
 		if highlight != null:
-			highlight.position = HexGrid.get_hex_center(HexGrid.get_hex_at(relative_pos))
+			highlight.position = hex_grid.get_hex_center(hex_grid.get_hex_at(relative_pos))

--- a/demo_3d.gd
+++ b/demo_3d.gd
@@ -1,7 +1,7 @@
 # Script to attach to a node which represents a hex grid
 extends Spatial
 
-var HexGrid = preload("./HexGrid.gd").new()
+var hex_grid = HexGrid.new()
 
 onready var highlight = get_node("Highlight")
 onready var plane_coords_label = get_node("Highlight/Viewport/PlaneCoords")
@@ -16,10 +16,10 @@ func _on_HexGrid_input_event(_camera, _event, click_position, _click_normal, _sh
 	if plane_coords_label != null:
 		plane_coords_label.text = str(plane_coords)
 	if hex_coords_label != null:
-		hex_coords_label.text = str(HexGrid.get_hex_at(plane_coords).axial_coords)
-	
+		hex_coords_label.text = str(hex_grid.get_hex_at(plane_coords).axial_coords)
+
 	# Snap the highlight to the nearest grid cell
 	if highlight != null:
-		var plane_pos = HexGrid.get_hex_center(HexGrid.get_hex_at(plane_coords))
+		var plane_pos = hex_grid.get_hex_center(hex_grid.get_hex_at(plane_coords))
 		highlight.translation.x = plane_pos.x
 		highlight.translation.z = plane_pos.y

--- a/project.godot
+++ b/project.godot
@@ -8,9 +8,20 @@
 
 config_version=4
 
-_global_script_classes=[  ]
+_global_script_classes=[ {
+"base": "Resource",
+"class": "HexCell",
+"language": "GDScript",
+"path": "res://addons/gdhexgrid/HexCell.gd"
+}, {
+"base": "Reference",
+"class": "HexGrid",
+"language": "GDScript",
+"path": "res://addons/gdhexgrid/HexGrid.gd"
+} ]
 _global_script_class_icons={
-
+"HexCell": "res://addons/gdhexgrid/icon_hex_cell.svg",
+"HexGrid": "res://addons/gdhexgrid/icon_hex_grid.svg"
 }
 
 [application]
@@ -21,7 +32,7 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "gut" )
+enabled=PoolStringArray( "gdhexgrid", "gut" )
 
 [rendering]
 

--- a/test/unit/test_hexcell.gd
+++ b/test/unit/test_hexcell.gd
@@ -2,64 +2,61 @@ extends "res://addons/gut/test.gd"
 
 class TestNew:
 	extends "res://addons/gut/test.gd"
-	
-	var HexCell = load("res://HexCell.gd")
+
 	var cell
-	
+
 	func setup():
 		cell = null
-		
-	
+
+
 	func test_null():
 		cell = HexCell.new()
 		assert_eq(cell.axial_coords, Vector2(0, 0))
-		
+
 	func test_cube():
 		cell = HexCell.new(Vector3(1, 1, -2))
 		assert_eq(cell.axial_coords, Vector2(1, 1))
-		
+
 	func test_axial():
 		cell = HexCell.new(Vector2(1, -1))
 		assert_eq(cell.axial_coords, Vector2(1, -1))
-		
+
 	func test_instance():
 		var test_cell = HexCell.new(Vector3(-1, 2, -1))
 		cell = HexCell.new(test_cell)
 		assert_eq(cell.axial_coords, Vector2(-1, 2))
-		
-	
+
+
 class TestConversions:
 	extends "res://addons/gut/test.gd"
-	
-	var HexCell = load("res://HexCell.gd")
+
 	var cell
-	
+
 	func setup():
 		cell = HexCell.new()
-		
-	
+
+
 	func test_axial_to_cube():
 		assert_eq(cell.axial_to_cube_coords(Vector2(2, 1)), Vector3(2, 1, -3))
 		assert_eq(cell.axial_to_cube_coords(Vector2(-1, -1)), Vector3(-1, -1, 2))
-		
+
 	func test_rounding():
 		assert_eq(cell.round_coords(Vector3(0.1, 0.5, -0.6)), Vector3(0, 1, -1))
 		assert_eq(cell.round_coords(Vector3(-0.4, -1.3, 1.7)), Vector3(-1, -1, 2))
-		
+
 		assert_eq(cell.round_coords(Vector2(-0.1, 0.6)), Vector3(0, 1, -1))
 		assert_eq(cell.round_coords(Vector2(4.2, -5.5)), Vector3(4, -5, 1))
-		
-	
+
+
 class TestCoords:
 	extends "res://addons/gut/test.gd"
-	
-	var HexCell = load("res://HexCell.gd")
+
 	var cell
-	
+
 	func setup():
 		cell = HexCell.new()
-		
-	
+
+
 	func test_from_cubic_positive():
 		cell.cube_coords = Vector3(2, 1, -3)
 		assert_eq(cell.cube_coords, Vector3(2, 1, -3))
@@ -73,7 +70,7 @@ class TestCoords:
 	func test_from_cubic_invalid():
 		cell.cube_coords = Vector3(1, 2, 3)
 		assert_eq(cell.cube_coords, Vector3(0, 0, 0))
-		
+
 	func test_from_axial_positive():
 		cell.axial_coords = Vector2(2, 1)
 		assert_eq(cell.cube_coords, Vector3(2, 1, -3))
@@ -84,7 +81,7 @@ class TestCoords:
 		assert_eq(cell.cube_coords, Vector3(-1, -1, 2))
 		assert_eq(cell.axial_coords, Vector2(-1, -1))
 		assert_eq(cell.offset_coords, Vector2(-1, -2))
-		
+
 	func test_from_offset_positive():
 		cell.offset_coords = Vector2(2, 2)
 		assert_eq(cell.cube_coords, Vector3(2, 1, -3))
@@ -95,24 +92,23 @@ class TestCoords:
 		assert_eq(cell.cube_coords, Vector3(-1, -1, 2))
 		assert_eq(cell.axial_coords, Vector2(-1, -1))
 		assert_eq(cell.offset_coords, Vector2(-1, -2))
-		
-	
+
+
 class TestNearby:
 	extends "res://addons/gut/test.gd"
-	
-	var HexCell = load("res://HexCell.gd")
+
 	var cell
-	
+
 	func setup():
 		cell = HexCell.new(Vector2(1, 2))
-	
+
 	func check_expected(cells, expected):
 		# Check that a bunch of cells are what were expected
 		assert_eq(cells.size(), expected.size())
 		for hex in cells:
 			assert_has(expected, hex.axial_coords)
-		
-	
+
+
 	func test_adjacent():
 		var foo = cell.get_adjacent(HexCell.DIR_N)
 		assert_eq(foo.axial_coords, Vector2(1, 3))
@@ -132,7 +128,7 @@ class TestNearby:
 	func test_adjacent_axial():
 		var foo = cell.get_adjacent(Vector2(1, 1))
 		assert_eq(foo.axial_coords, Vector2(2, 3))
-		
+
 	func test_all_adjacent():
 		var coords = []
 		for foo in cell.get_all_adjacent():
@@ -143,7 +139,7 @@ class TestNearby:
 		assert_has(coords, Vector2(1, 1))
 		assert_has(coords, Vector2(0, 2))
 		assert_has(coords, Vector2(0, 3))
-		
+
 	func test_all_within_0():
 		var expected = [
 			Vector2(1, 2),
@@ -174,7 +170,7 @@ class TestNearby:
 		]
 		var cells = cell.get_all_within(2)
 		check_expected(cells, expected)
-		
+
 	func test_ring_0():
 		var expected = [
 			Vector2(1, 2),
@@ -204,22 +200,21 @@ class TestNearby:
 		]
 		var cells = cell.get_ring(2)
 		check_expected(cells, expected)
-		
-	
+
+
 class TestBetweenTwo:
 	extends "res://addons/gut/test.gd"
-	
-	var HexCell = load("res://HexCell.gd")
+
 	var cell
-	
+
 	func setup():
 		cell = HexCell.new(Vector2(1, 2))
-	
+
 	func test_distance():
 		assert_eq(cell.distance_to(Vector2(0, 0)), 3)
 		assert_eq(cell.distance_to(Vector2(3, 4)), 4)
 		assert_eq(cell.distance_to(Vector2(-1, -1)), 5)
-		
+
 	func test_line_straight():
 		# Straight line, nice and simple
 		var expected = [
@@ -233,7 +228,7 @@ class TestBetweenTwo:
 		assert_eq(path.size(), expected.size())
 		for idx in range(expected.size()):
 			assert_eq(path[idx].axial_coords, expected[idx])
-		
+
 	func test_line_angled():
 		# It's gone all wibbly-wobbly
 		var expected = [
@@ -249,7 +244,7 @@ class TestBetweenTwo:
 		assert_eq(path.size(), expected.size())
 		for idx in range(expected.size()):
 			assert_eq(path[idx].axial_coords, expected[idx])
-		
+
 	func test_line_edge():
 		# Living on the edge between two hexes
 		var expected = [
@@ -263,4 +258,4 @@ class TestBetweenTwo:
 		assert_eq(path.size(), expected.size())
 		for idx in range(expected.size()):
 			assert_eq(path[idx].axial_coords, expected[idx])
-	
+

--- a/test/unit/test_hexgrid.gd
+++ b/test/unit/test_hexgrid.gd
@@ -1,7 +1,5 @@
 extends "res://addons/gut/test.gd"
 
-var HexCell = load("res://HexCell.gd")
-var HexGrid = load("res://HexGrid.gd")
 var cell
 var grid
 var w
@@ -12,7 +10,7 @@ func setup():
 	grid = HexGrid.new()
 	w = grid.hex_size.x
 	h = grid.hex_size.y
-	
+
 
 func test_hex_to_projection():
 	var tests = {
@@ -24,7 +22,7 @@ func test_hex_to_projection():
 	}
 	for hex in tests:
 		assert_eq(tests[hex], grid.get_hex_center(hex))
-	
+
 func test_hex_to_projection_scaled():
 	grid.set_hex_scale(Vector2(2, 2))
 	var tests = {
@@ -35,7 +33,7 @@ func test_hex_to_projection_scaled():
 	}
 	for hex in tests:
 		assert_eq(tests[hex], grid.get_hex_center(hex))
-	
+
 func test_hex_to_projection_squished():
 	grid.set_hex_scale(Vector2(2, 1))
 	var tests = {
@@ -46,7 +44,7 @@ func test_hex_to_projection_squished():
 	}
 	for hex in tests:
 		assert_eq(tests[hex], grid.get_hex_center(hex))
-	
+
 func test_hex_to_3d_projection():
 	var tests = {
 		Vector2(0, 0): Vector3(0, 0, 0),
@@ -61,7 +59,7 @@ func test_hex_to_3d_projection():
 		Vector3(0, 1.2, 0),
 		grid.get_hex_center3(Vector2(0, 0), 1.2)
 	)
-	
+
 
 func test_projection_to_hex():
 	var tests = {
@@ -79,7 +77,7 @@ func test_projection_to_hex():
 	}
 	for coords in tests:
 		assert_eq(tests[coords], grid.get_hex_at(coords).axial_coords)
-	
+
 func test_projection_to_hex_doublesquished():
 	grid.set_hex_scale(Vector2(4, 2))
 	var tests = {
@@ -94,4 +92,4 @@ func test_projection_to_hex_doublesquished():
 	}
 	for coords in tests:
 		assert_eq(tests[coords], grid.get_hex_at(coords).axial_coords)
-	
+

--- a/test/unit/test_pathfinding.gd
+++ b/test/unit/test_pathfinding.gd
@@ -1,7 +1,5 @@
 extends "res://addons/gut/test.gd"
 
-var HexCell = load("res://HexCell.gd")
-var HexGrid = load("res://HexGrid.gd")
 var grid
 var map
 # This is the hex map we'll test with:
@@ -74,7 +72,7 @@ func test_roundabounds():
 	assert_eq(grid.get_hex_cost(Vector2(0, 0)), grid.path_cost_default)
 	assert_eq(grid.get_hex_cost(Vector2(-4, 0)), 0)
 	assert_eq(grid.get_hex_cost(Vector2(0, 3)), 0)
-	
+
 func test_grid_obstacles():
 	# Make sure we can obstacleize the grid
 	assert_eq(grid.get_obstacles().size(), obstacles.size())
@@ -89,7 +87,7 @@ func test_grid_obstacles():
 	assert_does_not_have(grid.get_obstacles(), Vector2(0, 0))
 	# Make sure removing a non-obstacle doesn't error
 	grid.remove_obstacles(Vector2(0, 0))
-	
+
 func test_grid_barriers():
 	# Make sure we can barrier things on the grid
 	assert_eq(grid.get_barriers().size(), 0)
@@ -119,7 +117,7 @@ func test_grid_barriers():
 	assert_eq(barriers.size(), 0)
 	# Remove no barrier with no error
 	grid.remove_barriers([Vector2(1, 1), Vector2(2, 2)])
-	
+
 
 func test_hex_costs():
 	# Test that the price is right
@@ -128,7 +126,7 @@ func test_hex_costs():
 	# Test partial obstacle
 	grid.add_obstacles(Vector2(1, 1), 1.337)
 	assert_eq(grid.get_hex_cost(Vector2(1, 1)), 1.337, "9")
-	
+
 func test_move_costs():
 	# Test that more than just hex costs are at work
 	assert_eq(grid.get_move_cost(Vector2(0, 0), HexCell.DIR_N), grid.path_cost_default)
@@ -148,7 +146,7 @@ func test_move_cost_cumulative():
 	grid.add_barriers(Vector2(0, 0), HexCell.DIR_N, 4)
 	grid.add_barriers(Vector2(0, 1), HexCell.DIR_S, 8)
 	assert_eq(grid.get_move_cost(Vector2(0, 0), HexCell.DIR_N), 14)
-	
+
 
 func check_path(got, expected):
 	# Assert that the gotten path was the expected route
@@ -161,7 +159,7 @@ func check_path(got, expected):
 			assert_has(check, hex.axial_coords)
 		else:
 			assert_eq(check, hex.axial_coords)
-		
+
 func test_straight_line():
 	# Path between A and C is straight
 	var path = [
@@ -173,7 +171,7 @@ func test_straight_line():
 		c_pos,
 	]
 	check_path(grid.find_path(a_pos, c_pos), path)
-	
+
 func test_wonky_line():
 	# Path between B and C is a bit wonky
 	var path = [
@@ -183,7 +181,7 @@ func test_wonky_line():
 		c_pos,
 	]
 	check_path(grid.find_path(HexCell.new(b_pos), HexCell.new(c_pos)), path)
-	
+
 func test_obstacle():
 	# Path between A and B should go around the bottom
 	var path = [
@@ -195,7 +193,7 @@ func test_obstacle():
 		b_pos,
 	]
 	check_path(grid.find_path(a_pos, b_pos), path)
-	
+
 func test_walls():
 	# Test that we can't walk through walls
 	var walls = [
@@ -215,7 +213,7 @@ func test_walls():
 		g_pos,
 	]
 	check_path(grid.find_path(a_pos, g_pos), path)
-	
+
 func test_slopes():
 	# Test that we *can* walk through *some* walls
 	# A barrier which is passable, but not worth our hex
@@ -228,7 +226,7 @@ func test_slopes():
 		g_pos,
 	]
 	check_path(grid.find_path(a_pos, g_pos), path)
-	
+
 func test_rough_terrain():
 	# Path between A and B depends on the toughness of D
 	var short_path = [
@@ -263,7 +261,7 @@ func test_rough_terrain():
 	for cost in tests:
 		grid.add_obstacles(d_pos, cost)
 		check_path(grid.find_path(a_pos, b_pos), tests[cost])
-	
+
 func test_exception():
 	# D is impassable, so path between A and B should go around the top as well
 	var path = [
@@ -292,7 +290,7 @@ func test_exception_hex():
 		b_pos,
 	]
 	check_path(grid.find_path(a_pos, b_pos, [HexCell.new(d_pos)]), path)
-	
+
 func test_exceptional_goal():
 	# If D is impassable, we should path to its neighbour
 	var path = [
@@ -301,12 +299,12 @@ func test_exceptional_goal():
 		Vector2(4, 0),
 	]
 	check_path(grid.find_path(a_pos, d_pos, [d_pos]), path)
-	
+
 func test_inaccessible():
 	# E is inaccessible!
 	var path = grid.find_path(a_pos, e_pos)
 	assert_eq(path.size(), 0)
-	
+
 func test_obstacle_neighbour():
 	# Sometimes we can't get to something, but we can get next to it.
 	var path = [
@@ -316,7 +314,7 @@ func test_obstacle_neighbour():
 		Vector2(0, 3),
 	]
 	check_path(grid.find_path(a_pos, f_pos), path)
-	
+
 func test_difficult_goal():
 	# We should be able to path to a goal, no matter how difficult the final step
 	grid.add_obstacles(f_pos, 1337)
@@ -328,4 +326,4 @@ func test_difficult_goal():
 		f_pos,
 	]
 	check_path(grid.find_path(a_pos, f_pos), path)
-	
+


### PR DESCRIPTION
The scripts have been converted to classes, removing the need to directly reference the source files.

All the tests are successful _on my end_ and the scenes _appear_ to work as expected.

The icons are taken from [here](https://github.com/godotengine/godot/tree/4f5a7ebaecfcf00cf1e5c4af4b20034f0dcecd29/editor/icons) (they are the same icon used for the basic node, in this case they are meant to be just placeholders) and follow the same naming convention.

Since I didn't find it declared anywhere, I've marked the version as 1.0.0 (in the plugin configuration file), feel free to correct it if needed.